### PR TITLE
minor adjustment for menu availability

### DIFF
--- a/backend-express/routes/users.js
+++ b/backend-express/routes/users.js
@@ -62,7 +62,7 @@ router.get('/:id', function (req, res, next) {
   USING(Cart_Id)
   JOIN menu m
   USING(Menu_Id)
- where Cart_Id= '${req.params.id}';`;
+ where Cart_Id= '${req.params.id}' AND Available = 'Y';`;
 
   let connection = mysql.createConnection(dbCreds);
   connection.connect();


### PR DESCRIPTION
While prepping Postman lines for class presentation, I noticed the Issue #28 was not differentiating between available and not available items, and was displaying all options for that cart.  Added a minor adjustment for the sql query to only show "available = 'Y' ".