### PR TITLE
Hdc 64 vendor app nav menu

### DIFF
--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -6872,6 +6872,11 @@
         "slash": "^3.0.0"
       }
     },
+    "google-maps-react": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/google-maps-react/-/google-maps-react-2.0.6.tgz",
+      "integrity": "sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ=="
+    },
     "graceful-fs": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.6.3",
+    "google-maps-react": "^2.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -7,7 +7,6 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.6.3",
-    "google-maps-react": "^2.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/frontend-react/src/Nav.css
+++ b/frontend-react/src/Nav.css
@@ -9,7 +9,7 @@ ul.topnav {
     padding: 0;
     overflow: hidden;
     width: 90%;
-    background-color: rgb(95,95,95);
+    /* background-color: rgb(95,95,95); */
     
     display: flex;
     align-items: center;
@@ -19,28 +19,41 @@ ul.topnav {
 ul.topnav li a.selected {
         		background-color: darkcyan;
         		color:#000;
+            
    	 }
 
 
 /* Float the list items side by side */
 ul.topnav li {
     float: left;
+    width: 20%;
+    background-color: rgb(180, 179, 170);
+    text-align: center;
 }
 
 /* Style the links inside the list items */
 ul.topnav li a {
-    display: inline-block;
-    color: #f2f2f2;
+    display: block;
+    /* color: #f2f2f2; */
     text-align: center;
     padding: 14px 16px;
+    /* padding: 4% 30%; */
     text-decoration: none;
-    transition: 0.3s;
+    
     font-size: 17px;
-}
-
+} 
 
 /* Change background color of links on hover */
-ul.topnav li a:hover {background-color: lightseagreen;}
+ul.topnav li:hover {
+  background-color: lightseagreen;
+  color:white;
+  transition: 0.3s;
+}
+
+ul.topnav a:hover {
+  color: white;
+  transition: 0.3s;
+}
 
 /* Hide the list item that contains the link that should open and close the topnav on small screens */
 ul.topnav li.icon {display: none;}

--- a/frontend-react/src/VendorsApp/VendorMenu.js
+++ b/frontend-react/src/VendorsApp/VendorMenu.js
@@ -1,0 +1,68 @@
+import {
+    BrowserRouter as Router,
+    Switch,
+    Route,
+    Link
+  } from "react-router-dom";
+import CompOrderList from "../components/CompOrderList";
+import OrdersList from "../components/OrdersList";
+import VendorSettings from "../components/VendorSettings";
+import VendorMenuItems from "../components/VendorMenuItems";
+
+
+function VendorMenu () {
+    return (
+        <div>
+            {/* Vendor Menu - React Router */}
+            <Router>
+            <div>
+              <nav>
+                <ul className="topnav">
+                  <li className="tabcontent">
+                    <Link to="/vendor">Incomplete Orders</Link>
+                  </li>
+                  <li className="tabcontent">
+                    <Link to="/vendor/PickUpReady">Ready Orders</Link>
+                  </li>
+                  <li className="tabcontent">
+                    <Link to="/vendor/MenuSettings">Menu</Link>
+                  </li>
+                  <li className="tabcontent">
+                    <Link to="/vendor/CartSettings">Settings</Link>
+                  </li>
+                </ul>
+              </nav>
+
+              {/* A <Switch> looks through its children <Route>s and
+                  renders the first one that matches the current URL. */}
+              <Switch>
+                
+                <Route path="/vendor/PickUpReady">
+                <CompOrderList /> 
+                </Route>
+
+                <Route path="/vendor/MenuSettings">
+                  <VendorMenuItems />
+                </Route>
+
+                <Route path="/vendor/CartSettings">
+                  <VendorSettings />
+                </Route>
+
+                <Route path="/vendor">
+                  <OrdersList />
+                </Route>
+
+              </Switch>
+            </div>
+            
+            
+          </Router>
+         
+    
+        </div>
+    )
+}
+
+export default VendorMenu;
+

--- a/frontend-react/src/VendorsApp/VendorMenu.js
+++ b/frontend-react/src/VendorsApp/VendorMenu.js
@@ -17,7 +17,7 @@ function VendorMenu () {
             <Router>
             <div>
               <nav>
-                <ul className="topnav">
+                <ul id="vendorMenu" className="topnav">
                   <li className="tabcontent">
                     <Link to="/vendor">Incomplete Orders</Link>
                   </li>
@@ -58,11 +58,23 @@ function VendorMenu () {
             
             
           </Router>
-         
     
         </div>
     )
 }
 
+
 export default VendorMenu;
 
+{/* 
+// Add active class to the current button (highlight it) 
+const header = document.getElementById("vendorMenu");
+const btns = header.getElementsByClassName("tabcontent");
+for (var i = 0; i < btns.length; i++) {
+  btns[i].addEventListener("click", function() {
+  var current = document.getElementsByClassName("active");
+  current[0].className = current[0].className.replace(" active", "");
+  this.className += " active";
+  });
+}
+*/}

--- a/frontend-react/src/VendorsApp/VendorsApp.js
+++ b/frontend-react/src/VendorsApp/VendorsApp.js
@@ -1,9 +1,14 @@
+
 //import React from 'react';
 import ReactDOM from 'react-dom';
 
 import '../index.css';
 import '../Nav.css';
 import Header from'../components/Header';
+import VendorMenu from './VendorMenu';
+
+
+
 
 function VendorsApp () {
 
@@ -11,8 +16,13 @@ function VendorsApp () {
         <div>
             <Header />
             <h2 className="placeholder">VendorsApp Container</h2>
+            <VendorMenu />
+
+            
         </div>
     )
 }
 
+
+  
 export default VendorsApp;

--- a/frontend-react/src/components/CompOrderList.js
+++ b/frontend-react/src/components/CompOrderList.js
@@ -1,0 +1,15 @@
+//import Header from'./Header ';
+import '../index.css';
+import '../Nav.css';
+
+function CompOrderList  () {
+
+    return (
+        <div>
+            
+            <h2 className="placeholder">Completed Orders</h2>
+        </div>
+    )
+}
+
+export default CompOrderList;

--- a/frontend-react/src/components/Map.js
+++ b/frontend-react/src/components/Map.js
@@ -5,8 +5,10 @@ import apiKey from "../googleMapsApiKey.json";
 const Map = () => {
 
     const mapStyles = {
-        height: "100vh",
-        width: "100%"};
+        height: "90vh",
+        width: "90%",
+        margin: "1em auto"
+    };
 
     const defaultCenter = {
         lat: 47.65629189632677, lng: -122.32059609201939
@@ -17,7 +19,7 @@ const Map = () => {
     return (
         <LoadScript
          googleMapsApiKey={apiKey.key}>
-            <GoogleMap
+            <GoogleMap className="mapimage" 
              mapContainerStyle={mapStyles}
              zoom={13}
              center={defaultCenter}

--- a/frontend-react/src/components/OrdersList.js
+++ b/frontend-react/src/components/OrdersList.js
@@ -1,0 +1,15 @@
+//import Header from'./Header ';
+import '../index.css';
+import '../Nav.css';
+
+function OrdersList  () {
+
+    return (
+        <div>
+            
+            <h2 className="placeholder">Incomplete Orders</h2>
+        </div>
+    )
+}
+
+export default OrdersList;

--- a/frontend-react/src/components/VendorMenuItems.js
+++ b/frontend-react/src/components/VendorMenuItems.js
@@ -1,0 +1,15 @@
+//import Header from'./Header ';
+import '../index.css';
+import '../Nav.css';
+
+function VendorMenuItems  () {
+
+    return (
+        <div>
+            
+            <h2 className="placeholder">Menu Settings</h2>
+        </div>
+    )
+}
+
+export default VendorMenuItems;

--- a/frontend-react/src/components/VendorSettings.js
+++ b/frontend-react/src/components/VendorSettings.js
@@ -1,0 +1,15 @@
+//import Header from'./Header ';
+import '../index.css';
+import '../Nav.css';
+
+function VendorSettings  () {
+
+    return (
+        <div>
+            
+            <h2 className="placeholder">Settings</h2>
+        </div>
+    )
+}
+
+export default VendorSettings;

--- a/frontend-react/src/index.css
+++ b/frontend-react/src/index.css
@@ -51,12 +51,14 @@ p {
 a {
   color:mediumblue;
   text-decoration: none;
-  background-color: lightyellow;
+  /*background-color: rgb(180, 179, 170); */
+  border-radius: 25px;
 }
 
-a:hover {
-  color:white;
-  background-color:mediumblue;
+
+.tabcontent {
+  border: 1px solid;
+  border-radius: 25px;
 }
 
 .mapimage {


### PR DESCRIPTION
This adds menu navigation to the Vendors App page. Navigation links to load to components for Incomplete Orders, Completed Orders, Menu List and Settings.  Currently, the nav links point to placeholder components with just text.
![HDC-64-Vendor-menu](https://user-images.githubusercontent.com/49133101/109918426-c3028800-7c6b-11eb-87be-4f2eddeea532.PNG)
