### PR TITLE
Hdc 46 backend routes for apps

### DIFF
--- a/backend-express/app.js
+++ b/backend-express/app.js
@@ -23,8 +23,8 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
-//app.use('/vendor', vendorRouter);
-//app.use('/admin', adminRouter);
+app.use('/vendor', vendorRouter);
+app.use('/admin', adminRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/backend-express/app.js
+++ b/backend-express/app.js
@@ -6,6 +6,8 @@ var logger = require('morgan');
 
 var indexRouter = require('./routes/index');
 var usersRouter = require('./routes/users');
+var vendorRouter = require('./routes/vendor');
+var adminRouter = require('./routes/admin')
 
 var app = express();
 
@@ -21,6 +23,8 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
+app.use('/vendor', vendorRouter);
+//app.use('/admin', adminRouter);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/backend-express/app.js
+++ b/backend-express/app.js
@@ -23,7 +23,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
-app.use('/vendor', vendorRouter);
+//app.use('/vendor', vendorRouter);
 //app.use('/admin', adminRouter);
 
 // catch 404 and forward to error handler

--- a/backend-express/routes/admin.js
+++ b/backend-express/routes/admin.js
@@ -1,0 +1,19 @@
+var express = require('express');
+let mysql = require('mysql2');
+let dbCreds = require("../../../dbCreds.json");
+var router = express.Router();
+
+/* ADMIN - this function/call outputs all the menu details from the menu table */
+router.get('/admin/Menu', function (req, res, next) {
+    let connection = mysql.createConnection(dbCreds);
+    connection.connect();
+  
+    connection.query('SELECT * FROM Menu', (error, results, fields) => {
+      if (error) {
+        res.send(500);
+      }
+      res.status(200).send(results);
+    })
+  
+    connection.end();
+  });

--- a/backend-express/routes/admin.js
+++ b/backend-express/routes/admin.js
@@ -3,8 +3,8 @@ let mysql = require('mysql2');
 let dbCreds = require("../../../dbCreds.json");
 var router = express.Router();
 
-/* ADMIN - this function/call outputs all the menu details from the menu table */
-router.get('/admin/Menu', function (req, res, next) {
+/* ADMIN - see all the menu details from the menu table */
+router.get('/menu', function (req, res, next) {
     let connection = mysql.createConnection(dbCreds);
     connection.connect();
   
@@ -17,3 +17,48 @@ router.get('/admin/Menu', function (req, res, next) {
   
     connection.end();
   });
+
+  /* VENDOR/ADMIN - GET all Menu items for a specific cart */
+router.get('/menus/cart/:id', function (req, res, next) {
+    let connection = mysql.createConnection(dbCreds);
+    connection.connect();
+  
+    connection.query(`SELECT Cart_Id, cartmenus.Menu_Id, Menu_Name, Menu_Description, Menu_Price, Available
+    FROM cartmenus
+    INNER JOIN menu ON cartmenus.Menu_Id = menu.Menu_Id
+    WHERE Cart_Id = ?;`, [req.params.id], (error, results) => {
+      /* if req.params.id doesn't match a Cart_Id, return 404 http status and a "cart not found" msg */
+      if (results.length === 0) {
+  
+        res.status(404).send("Cart Not Found");
+
+      }
+      else if (error) {
+        res.sendStatus(500);
+      } else {
+  
+        res.status(200).send(results);
+      }
+    })
+
+    connection.end();
+  
+  });
+
+  /* ADMIN - this function/call outputs all the customer details from customer table*/
+router.get('/customers', function (req, res, next) {
+    let connection = mysql.createConnection(dbCreds);
+    connection.connect();
+  
+    connection.query('SELECT * FROM Customer', (error, results, fields) => {
+      if (error) {
+        res.send(500);
+      }
+      res.status(200).send(results);
+    })
+  
+    connection.end();
+  });
+
+
+  module.exports = router;

--- a/backend-express/routes/users.js
+++ b/backend-express/routes/users.js
@@ -3,24 +3,9 @@ let mysql = require('mysql2');
 let dbCreds = require("../../../dbCreds.json");
 var router = express.Router();
 
-/* GET users listing. */
-router.get('/', function(req, res, next) {
-  //let mySQLQuery = "SELECT * FROM Orders";
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
 
-  connection.query('SELECT * FROM Customer',(error, results) =>{
-    
-    if(error){
-      res.send(500);
-    }
-    res.send(results);
-  }) 
 
-  connection.end();
-});
-
-/* GET All Menu items for a specific cart - Vendor/SysAdmin */
+/* VENDOR/ADMIN - GET All Menu items for a specific cart */
 router.get('/Menus/:id', function (req, res, next) {
   let connection = mysql.createConnection(dbCreds);
   connection.connect();
@@ -52,7 +37,7 @@ router.get('/Menus/:id', function (req, res, next) {
 
 module.exports = router;
 
-//get all the cart details when customer makes a get call - Customer
+//CUSTOMER - get all the cart details when customer makes a get call
 router.get('/:id', function (req, res, next) {
 
   let getCartDetails = `SELECT Cart_Id,Menu_Id,Employee_FirstName,Cart_Location,Menu_Name,Menu_Description,Menu_Price FROM employees e JOIN carts c
@@ -83,58 +68,14 @@ router.get('/:id', function (req, res, next) {
 
 
 
-// API GET path for seeing all current order for a single cart - Vendor
-router.get('/Orders/:id', function (req, res, next) {
 
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
-
-  connection.query(`SELECT Orders.Order_Id,Order_Total,Customer_Id,Order_Date,Order_Status, Cart_Id, ordersitems.OrderItem_Id, Menu_Name, Menu_Price, Quantity FROM Orders 
-  
-  INNER JOIN ordersDetails ON Orders.Order_Id = ordersDetails.Order_Id
-  INNER JOIN ordersItems ON ordersdetails.OrderItem_Id = ordersitems.OrderItem_Id
-  INNER JOIN menu ON menu.Menu_Id = ordersitems.Menu_Id  
-  
-  WHERE Cart_Id = ?;`, [req.params.id], (error, results) => {
-    /*  if (results == undefined){
-       res.status(404).send("Order unavailable");
-     } */
-
-    if (error) {
-      res.send(500);
-    }
-    else if (error) {
-      res.sendStatus(500);
-    } else {
-      res.status(200).send(results);
-    }
-
-  })
-
-  connection.end();
-});
-
-/*Issue 42 GET page for admin/menu- this function/call outputs all the menu details from the menu table */
-router.get('/admin/Menu', function (req, res, next) {
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
-
-  connection.query('SELECT * FROM Menu', (error, results, fields) => {
-    if (error) {
-      res.send(500);
-    }
-    res.status(200).send(results);
-  })
-
-  connection.end();
-});
 
 /* router.put('/:id', function(req, res, next) {
   
   let connection = mysql.createConnection(dbCreds);
   connection.connect();
 
-/*Issue 36 GET page for admin/Customer- this function/call outputs all the customer details from customer table*/
+/* ADMIN - this function/call outputs all the customer details from customer table*/
 router.get('/admin/Customers', function (req, res, next) {
   let connection = mysql.createConnection(dbCreds);
   connection.connect();
@@ -150,7 +91,7 @@ router.get('/admin/Customers', function (req, res, next) {
 });
 
 
-// Issue #27 - Info summary for modal for selected cart on map
+// CUSTOMER - Info summary for modal for selected cart on map
 router.get('/map/:id', function(req, res, next) {
   let connection = mysql.createConnection(dbCreds);
   connection.connect();
@@ -177,6 +118,7 @@ router.get('/map/:id', function(req, res, next) {
     connection.end();
 })
 
+/* VENDOR - Retrieve all details for a specific order */
 router.get('/Orders/order/:id', function(req, res, next) {
   
   let connection = mysql.createConnection(dbCreds);

--- a/backend-express/routes/users.js
+++ b/backend-express/routes/users.js
@@ -4,41 +4,8 @@ let dbCreds = require("../../../dbCreds.json");
 var router = express.Router();
 
 
-
-/* VENDOR/ADMIN - GET All Menu items for a specific cart */
-router.get('/Menus/:id', function (req, res, next) {
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
-
-  connection.query(`SELECT Cart_Id, cartmenus.Menu_Id, Menu_Name, Menu_Description, Menu_Price, Available
-  FROM cartmenus
-  INNER JOIN menu ON cartmenus.Menu_Id = menu.Menu_Id
-  WHERE Cart_Id = ?;`, [req.params.id], (error, results) => {
-    /* if req.params.id doesn't match a Cart_Id, return 204 http status and a "no cart found msg"? */
-    if (results.length === 0) {
-
-      /* I Can't get it to display the below message if it's already successfully displayed cart info
-          UPDATE--apparently 204 won't update the results displayed. 404 actually fixes the issue as desired */
-      res.status(404).send("Cart Not Found");
-      /* res.status(204).send('Cart Not Found'); */
-    }
-    else if (error) {
-      res.sendStatus(500);
-    } else {
-
-      /*res.send(results, 200); */
-      res.status(200).send(results);
-    }
-  })
-  /* test comment */
-  connection.end();
-
-});
-
-module.exports = router;
-
-//CUSTOMER - get all the cart details when customer makes a get call
-router.get('/:id', function (req, res, next) {
+//CUSTOMER - get full cart details when customer selects a cart (from summary modal)
+router.get('/cart/:id', function (req, res, next) {
 
   let getCartDetails = `SELECT Cart_Id,Menu_Id,Employee_FirstName,Cart_Location,Menu_Name,Menu_Description,Menu_Price FROM employees e JOIN carts c
   USING(Employee_id )
@@ -68,29 +35,6 @@ router.get('/:id', function (req, res, next) {
 
 
 
-
-
-/* router.put('/:id', function(req, res, next) {
-  
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
-
-/* ADMIN - this function/call outputs all the customer details from customer table*/
-router.get('/admin/Customers', function (req, res, next) {
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
-
-  connection.query('SELECT * FROM Customer', (error, results, fields) => {
-    if (error) {
-      res.send(500);
-    }
-    res.status(200).send(results);
-  })
-
-  connection.end();
-});
-
-
 // CUSTOMER - Info summary for modal for selected cart on map
 router.get('/map/:id', function(req, res, next) {
   let connection = mysql.createConnection(dbCreds);
@@ -118,30 +62,8 @@ router.get('/map/:id', function(req, res, next) {
     connection.end();
 })
 
-/* VENDOR - Retrieve all details for a specific order */
-router.get('/Orders/order/:id', function(req, res, next) {
-  
-  let connection = mysql.createConnection(dbCreds);
-  connection.connect();
-
-  connection.query(`SELECT orders.Order_Id,Order_Total,Customer_Id,Order_Date,Order_Status, Cart_Id, ordersitems.OrderItem_Id, Menu_Name, Menu_Price, Quantity FROM orders 
-  
-  INNER JOIN ordersdetails ON orders.Order_Id = ordersdetails.Order_Id
-  INNER JOIN ordersitems ON ordersdetails.OrderItem_Id = ordersitems.OrderItem_Id
-  INNER JOIN menu ON menu.Menu_Id = ordersitems.Menu_Id  
-  
-  WHERE orders.Order_Id = ?;`,[req.params.id],  (error, results) =>{
-
-    if (results.length === 0) {
-      res.status(404).send("Order Not Found");
-    }
-    else if (error) {
-      res.sendStatus(500);
-    } else {
-      res.status(200).send(results);
-    }
-  })
-  connection.end();
-});
 
 
+
+
+module.exports = router;

--- a/backend-express/routes/vendor.js
+++ b/backend-express/routes/vendor.js
@@ -1,0 +1,37 @@
+var express = require('express');
+let mysql = require('mysql2');
+let dbCreds = require("../../../dbCreds.json");
+var router = express.Router();
+
+
+
+/* VENDOR - API GET path for seeing all current order for a single cart */
+router.get('/Orders/:id', function (req, res, next) {
+
+  let connection = mysql.createConnection(dbCreds);
+  connection.connect();
+
+  connection.query(`SELECT Orders.Order_Id,Order_Total,Customer_Id,Order_Date,Order_Status, Cart_Id, ordersitems.OrderItem_Id, Menu_Name, Menu_Price, Quantity FROM Orders 
+  
+  INNER JOIN ordersDetails ON Orders.Order_Id = ordersDetails.Order_Id
+  INNER JOIN ordersItems ON ordersdetails.OrderItem_Id = ordersitems.OrderItem_Id
+  INNER JOIN menu ON menu.Menu_Id = ordersitems.Menu_Id  
+  
+  WHERE Cart_Id = ?;`, [req.params.id], (error, results) => {
+    /*  if (results == undefined){
+       res.status(404).send("Order unavailable");
+     } */
+
+    if (error) {
+      res.send(500);
+    }
+    else if (error) {
+      res.sendStatus(500);
+    } else {
+      res.status(200).send(results);
+    }
+
+  })
+
+  connection.end();
+});

--- a/backend-express/routes/vendor.js
+++ b/backend-express/routes/vendor.js
@@ -3,10 +3,20 @@ let mysql = require('mysql2');
 let dbCreds = require("../../../dbCreds.json");
 var router = express.Router();
 
+/* VENDOR - default path response */
+router.get('/', function(req, res, next) {
+    res.send('please include cart number.');
+  });
 
 
-/* VENDOR - API GET path for seeing all current order for a single cart */
-router.get('/Orders/:id', function (req, res, next) {
+
+/* VENDOR - API GET path for seeing all current orders for a single cart */
+/* ** MAY NEED TO ADD "DONE" VS. "IN PROGRESS" TO WHERE FILTER!  ** 
+   ** adjust api path to be /orders/done/:id and /orders/inc/:id **
+   ** for vendors, but duplicate this route for an admin view?   **
+   ** Will also need to add more sample data for orders to DB of **
+   ** multiple done, in progress for each cart.                  ** */
+router.get('/orders/cart/:id', function (req, res, next) {
 
   let connection = mysql.createConnection(dbCreds);
   connection.connect();
@@ -35,3 +45,60 @@ router.get('/Orders/:id', function (req, res, next) {
 
   connection.end();
 });
+
+/* VENDOR - Retrieve all details for a specific order */
+router.get('/orders/order/:id', function(req, res, next) {
+  
+    let connection = mysql.createConnection(dbCreds);
+    connection.connect();
+  
+    connection.query(`SELECT orders.Order_Id,Order_Total,Customer_Id,Order_Date,Order_Status, Cart_Id, ordersitems.OrderItem_Id, Menu_Name, Menu_Price, Quantity FROM orders 
+    
+    INNER JOIN ordersdetails ON orders.Order_Id = ordersdetails.Order_Id
+    INNER JOIN ordersitems ON ordersdetails.OrderItem_Id = ordersitems.OrderItem_Id
+    INNER JOIN menu ON menu.Menu_Id = ordersitems.Menu_Id  
+    
+    WHERE orders.Order_Id = ?;`,[req.params.id],  (error, results) =>{
+  
+      if (results.length === 0) {
+        res.status(404).send("Order Not Found");
+      }
+      else if (error) {
+        res.sendStatus(500);
+      } else {
+        res.status(200).send(results);
+      }
+    })
+    connection.end();
+  });
+
+/* VENDOR/ADMIN - GET all Menu items for a specific cart */
+/* this is also on the admin.js */
+router.get('/menus/cart/:id', function (req, res, next) {
+    let connection = mysql.createConnection(dbCreds);
+    connection.connect();
+  
+    connection.query(`SELECT Cart_Id, cartmenus.Menu_Id, Menu_Name, Menu_Description, Menu_Price, Available
+    FROM cartmenus
+    INNER JOIN menu ON cartmenus.Menu_Id = menu.Menu_Id
+    WHERE Cart_Id = ?;`, [req.params.id], (error, results) => {
+      /* if req.params.id doesn't match a Cart_Id, return 404 http status and a "cart not found" msg */
+      if (results.length === 0) {
+  
+        res.status(404).send("Cart Not Found");
+
+      }
+      else if (error) {
+        res.sendStatus(500);
+      } else {
+  
+        res.status(200).send(results);
+      }
+    })
+
+    connection.end();
+  
+  });
+
+
+module.exports = router;

--- a/frontend-react/package-lock.json
+++ b/frontend-react/package-lock.json
@@ -6872,6 +6872,11 @@
         "slash": "^3.0.0"
       }
     },
+    "google-maps-react": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/google-maps-react/-/google-maps-react-2.0.6.tgz",
+      "integrity": "sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ=="
+    },
     "graceful-fs": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.6.3",
+    "google-maps-react": "^2.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -7,7 +7,6 @@
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/react": "^11.2.5",
     "@testing-library/user-event": "^12.6.3",
-    "google-maps-react": "^2.0.6",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/frontend-react/src/components/Map.js
+++ b/frontend-react/src/components/Map.js
@@ -5,8 +5,10 @@ import apiKey from "../googleMapsApiKey.json";
 const Map = () => {
 
     const mapStyles = {
-        height: "100vh",
-        width: "100%"};
+        height: "90vh",
+        width: "90%",
+        margin: "1em auto"
+    };
 
     const defaultCenter = {
         lat: 47.65629189632677, lng: -122.32059609201939
@@ -17,7 +19,7 @@ const Map = () => {
     return (
         <LoadScript
          googleMapsApiKey={apiKey.key}>
-            <GoogleMap
+            <GoogleMap className="mapimage" 
              mapContainerStyle={mapStyles}
              zoom={13}
              center={defaultCenter}


### PR DESCRIPTION
This issue created new backend-express routes: vendor.js and admin.js. all created api GET paths that were all on users.js have been sorted out so not every api call has to begin with "users/".  

ALSO: In moving the api paths around appropriately, I did adjust some path names to make more intuitive sense.  any path that called for a ":id" at the end, but wasnt clear it if was referring to an order or a cart, I added a clarifying element to the path name.  

One example--Seeing all Orders for a specific cart was "/Orders/:id", but that wasn't clear if :id should refer to cart number or an order number. So it was changed to "/orders/cart/:id".

**Note: any current components that are fetching from the db, may have to have their fetch routes adjusted.  
**Note: any saved Postman paths for testing vendor/admin calls will need to be recreated.